### PR TITLE
Switch away from default namespace

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -12,5 +12,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: quay.io/joconnel/cluster-impairment-operator
+  newName: quay.io/redhat-performance/cluster-impairment-operator
   newTag: latest

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -16,3 +16,7 @@ resources:
 - auth_proxy_role.yaml
 - auth_proxy_role_binding.yaml
 - auth_proxy_client_clusterrole.yaml
+# The following two lines are so the playbook has permission
+# to deploy its daemonset
+- network_service_account.yaml
+- network_scc.yaml

--- a/config/rbac/network_scc.yaml
+++ b/config/rbac/network_scc.yaml
@@ -1,0 +1,22 @@
+kind: SecurityContextConstraints
+metadata:
+  creationTimestamp: null
+  name: network-access-all
+allowHostDirVolumePlugin: true
+allowHostIPC: false
+allowHostNetwork: true
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegedContainer: true
+allowedCapabilities: []
+apiVersion: security.openshift.io/v1
+defaultAddCapabilities: []
+priority: null
+readOnlyRootFilesystem: false
+requiredDropCapabilities: []
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+users:
+- system:serviceaccount:cluster-impairment-operator:network-access

--- a/config/rbac/network_service_account.yaml
+++ b/config/rbac/network_service_account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: network-access
+  namespace: cluster-impairment-operator

--- a/container/apply-impairments.py
+++ b/container/apply-impairments.py
@@ -99,7 +99,6 @@ def parse_tc_netem_args():
   latency_evar = int(os.environ.get("LATENCY", 0))
   packet_loss_evar = float(os.environ.get("PACKET_LOSS", 0))
   bandwidth_limit_evar = int(os.environ.get("BANDWIDTH_LIMIT", 0))
-  logger.info(bandwidth_limit_evar)
   if latency_evar > 0:
     args["latency"] = ["delay", "{}ms".format(latency_evar)]
   if packet_loss_evar > 0:
@@ -175,7 +174,6 @@ def main():
 
   # Now, the impairments
 
-  start_time = time.time()
   netem_impairments = parse_tc_netem_args()
   duration = int(os.environ.get("DURATION", -1)) # Seconds
   start_time = int(os.environ.get("START_TIME", time.time())) # Epoch
@@ -199,6 +197,9 @@ def main():
     return
 
   current_time = time.time()
+
+  logger.info("Set to run for {}s. End time in {}s".format(end_time - start_time,
+    end_time - current_time))
 
   if current_time < start_time and running:
     logger.info("Waiting to run impairments")

--- a/manifests/impairment-daemonset.yaml
+++ b/manifests/impairment-daemonset.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: cluster-impairment-initializer
-  namespace: default
+  namespace: cluster-impairment-operator
   labels:
     k8s-app: cluster-impairment
 spec:
@@ -14,7 +14,7 @@ spec:
       labels:
         name: cluster-impairment
     spec:
-      initContainers:
+      containers:
         - name: impairment-worker
           image: quay.io/redhat-performance/cluster-impairment-worker
           env:
@@ -35,19 +35,10 @@ spec:
           volumeMounts:
           - mountPath: /lib/modules
             name: modprobe-modules-dir
-      containers:
-        - name: pause
-          image: gcr.io/google_containers/pause
-          resources:
-            limits:
-              cpu: 50m
-              memory: 50Mi
-            requests:
-              cpu: 50m
-              memory: 50Mi
       volumes:
       - name: modprobe-modules-dir
         hostPath:
           path: /lib/modules
       hostNetwork: true
       dnsPolicy: Default
+      serviceAccountName: network-access

--- a/manifests/impairment-daemonset.yaml
+++ b/manifests/impairment-daemonset.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       initContainers:
         - name: impairment-worker
-          image: quay.io/joconnel/cluster-impairment-operator-worker
+          image: quay.io/redhat-performance/cluster-impairment-worker
           env:
           - name: INTERFACE
             value: "ens2f0"
@@ -45,9 +45,9 @@ spec:
             requests:
               cpu: 50m
               memory: 50Mi
-  hostNetwork: true
-  dnsPolicy: Default
-  volumes:
-  - name: modprobe-modules-dir
-    hostPath:
-      path: /lib/modules
+      volumes:
+      - name: modprobe-modules-dir
+        hostPath:
+          path: /lib/modules
+      hostNetwork: true
+      dnsPolicy: Default

--- a/manifests/serviceaccount.yaml
+++ b/manifests/serviceaccount.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: network-access
+  namespace: cluster-impairment-operator
+---
+kind: SecurityContextConstraints
+metadata:
+  creationTimestamp: null
+  name: network-access-all
+allowHostDirVolumePlugin: true
+allowHostIPC: false
+allowHostNetwork: true
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegedContainer: true
+allowedCapabilities: []
+apiVersion: security.openshift.io/v1
+defaultAddCapabilities: []
+priority: null
+readOnlyRootFilesystem: false
+requiredDropCapabilities: []
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+users:
+- system:serviceaccount:cluster-impairment-operator:network-access

--- a/playbooks/roles/deploy-impairment-workers/templates/impairment-daemonset.yaml.j2
+++ b/playbooks/roles/deploy-impairment-workers/templates/impairment-daemonset.yaml.j2
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: cluster-impairment-initializer
-  namespace: default
+  namespace: cluster-impairment-operator
   labels:
     k8s-app: cluster-impairment-initializer
 spec:
@@ -55,3 +55,4 @@ spec:
           path: /lib/modules
       hostNetwork: true
       dnsPolicy: Default
+      serviceAccountName: network-access

--- a/playbooks/roles/deploy-impairment-workers/templates/impairment-daemonset.yaml.j2
+++ b/playbooks/roles/deploy-impairment-workers/templates/impairment-daemonset.yaml.j2
@@ -18,7 +18,7 @@ spec:
         "{{ node_selector_key }}": "{{ node_selector_value }}"
       containers:
         - name: impairment-worker
-          image: quay.io/joconnel/cluster-impairment-operator-worker
+          image: quay.io/redhat-performance/cluster-impairment-worker
           env:
           - name: INTERFACE
             value: "{{ impairment_interface }}"

--- a/playbooks/roles/deploy-impairment-workers/templates/impairment-daemonset.yaml.j2
+++ b/playbooks/roles/deploy-impairment-workers/templates/impairment-daemonset.yaml.j2
@@ -34,6 +34,8 @@ spec:
             value: "{{ impairment_loss }}"
           - name: START_TIME
             value: "{{ start_time_epoch }}"
+          - name: END_TIME
+            value: "{{ end_time_epoch }}"
           - name: LINK_FLAPPING
             value: "{{ impairment_link_flapping }}"
           - name: LINK_FLAP_DOWN_TIME


### PR DESCRIPTION
Also moved more stuff to redhat-performance, and fixed a bug that resulted in your duration being ignored.